### PR TITLE
Always add var.security_groups to launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ data "aws_eks_cluster" "this" {
 
 # Support keeping 2 node groups in sync by extracting common variable settings
 locals {
-  ng_needs_remote_access = local.remote_access_enabled && !local.use_launch_template
+  ng_needs_remote_access = local.remote_access_enabled && ! local.use_launch_template
   ng = {
     cluster_name  = var.cluster_name
     node_role_arn = join("", aws_iam_role.default.*.arn)
@@ -135,7 +135,7 @@ resource "random_pet" "cbd" {
 # WARNING TO MAINTAINERS: both node groups should be kept exactly in sync
 # except for count, lifecycle, and node_group_name.
 resource "aws_eks_node_group" "default" {
-  count           = local.enabled && !var.create_before_destroy ? 1 : 0
+  count           = local.enabled && ! var.create_before_destroy ? 1 : 0
   node_group_name = module.label.id
 
   lifecycle {


### PR DESCRIPTION
## what
* If `var.security_groups` is present, add any passed in security groups to the default cluster security group.

## why
* `var.security_groups` is only added to the launch template if `var.remote_access_enabled` is true. Additional security groups should not be dependent on SSH access being enabled to be used.
* Specifically, ran into an issue when using a x-account shared VPC where the default security group for the VPC was not available to accounts the VPC was shared with. After encountering this error, when attempting to specify a security group for the launch template using `var.security_groups`, realized this var isn't active unless `var.remote_access_enabled` is also set. See below for output:
```
Error: error creating EKS Node Group (my-eks-node-group): InvalidRequestException: You do not have access to a default security group in VPC vpc-123456. Specify a security group, 310. Specify a security group, and try again.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "4a670b03-66e0-4ec2-8f42-4254c32588a4"
│   },
│   Message_: "You do not have access to a default security group in VPC vpc-123456. Specify a security group, and try again."
│ }
```

This seems to be mostly a workaround for launch templates as EKS managed nodegroups should be auto-assigned to the default cluster security group, even if the launch template has no security groups attached to it.

Issue was present in v0.19.0 only when using `var.kubernetes_taints`, but in >=v0.20.0 this issue applied to all nodegroups created with this module.

## references
* Using AWS provider v3.50.0

